### PR TITLE
Adding TypeScript typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare const domains: string[];
+export = domains;

--- a/package.json
+++ b/package.json
@@ -3,5 +3,6 @@
   "version": "1.0.9",
   "repository": "https://github.com/ivolo/disposable-email-domains.git",
   "license": "MIT",
-  "main": "./index.json"
+  "main": "./index.json",
+  "typings": "./index.d.ts",
 }


### PR DESCRIPTION
Allows the repo to be identified as a string array in TypeScript

```ts
import * as disposable from 'disposable-email-domains';
// disposable is string[]
```