### PR TITLE
Adding hostcalls.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -485,6 +485,7 @@
   "hochsitze.com",
   "hoer.pw",
   "hopemail.biz",
+  "hostcalls.com",
   "hot-mail.cf",
   "hot-mail.ga",
   "hot-mail.gq",


### PR DESCRIPTION
Looks like `hostcalls.com` is just a front for `temp-mail.ru`
```
$ dig -t MX hostcalls.com @8.8.8.8

; <<>> DiG 9.8.3-P1 <<>> -t MX hostcalls.com @8.8.8.8
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 65095
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;hostcalls.com.			IN	MX

;; ANSWER SECTION:
hostcalls.com.		299	IN	MX	20 lord.temp-mail.ru.
hostcalls.com.		299	IN	MX	10 lord.temp-mail.org.

;; Query time: 56 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Tue Oct 11 12:41:21 2016
;; MSG SIZE  rcvd: 98
```