### PR TITLE
Adds md5hashing.net

### DIFF
--- a/index.json
+++ b/index.json
@@ -962,6 +962,7 @@
   "mbe.kr",
   "mbx.cc",
   "mciek.com",
+  "md5hashing.net",
   "mega.zik.dj",
   "meinspamschutz.de",
   "meltmail.com",


### PR DESCRIPTION
Seeing a large number of fake users making use of md5hashing.net. Seems to stem from [this service](https://md5hashing.net/anonymous/email).