### PR TITLE
Adds ibsats.com (www.throwawaymail.com)

### DIFF
--- a/index.json
+++ b/index.json
@@ -853,6 +853,7 @@
   "i.xcode.ro",
   "i201zzf8x.com",
   "i2pmail.org",
+  "ibsats.com",
   "ichigo.me",
   "ideer.msk.ru",
   "ideer.pro",


### PR DESCRIPTION
We have encountered a number of abusers making use of ibsats.com - a quick google search shows it as belonging to www.throwawaymail.com.

<3 your work!