### PR TITLE
Add 9toplay.com, zebra.email and ziyap.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -129,6 +129,7 @@
   "9mail.cf",
   "9me.site",
   "9ox.net",
+  "9toplay.com",
   "a-b.co.za",
   "a-bc.net",
   "a.betr.co",

--- a/index.json
+++ b/index.json
@@ -3488,6 +3488,7 @@
   "zaktouni.fr",
   "zane.rocks",
   "ze.gally.jp",
+  "zebra.email",
   "zehnminutenmail.de",
   "zepp.dk",
   "zesta.cf",

--- a/index.json
+++ b/index.json
@@ -3502,6 +3502,7 @@
   "zipcad.com",
   "zippymail.info",
   "zipzaprap.beerolympics.se",
+  "ziyap.com",
   "zoaxe.com",
   "zoemail.com",
   "zoemail.net",


### PR DESCRIPTION
[We](https://zeit.co) are seeing malicious traffic coming from such domains.

[zebra.email](http://zebra.email) and [ziyap.com](http://ziyap.com) clearly offer disposable emails. 9toplay.com's website is not being served at the moment, but [it can be found in other blacklists](https://github.com/phillipp/spam_email/blob/master/lib/spam_email/blacklist.rb#L138).