### PR TITLE
Remove sohu.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -3017,7 +3017,6 @@
   "softpls.asia",
   "sogetthis.com",
   "sohai.ml",
-  "sohu.com",
   "soisz.com",
   "solar-impact.pro",
   "solvemail.info",


### PR DESCRIPTION
This seems like a "free email provider" (albeit in chinese) rather than a "disposable email provider".

It was originally added in commit 8def12 which imported martenson/disposable-email-domains. That in turn added it in martenson/disposable-email-domains@ce7d3f.