### PR TITLE
Add loanins.org to the list

### DIFF
--- a/index.json
+++ b/index.json
@@ -2143,6 +2143,7 @@
   "lmcudh4h.com",
   "loadby.us",
   "loan101.pro",
+  "loanins.org",
   "loaoa.com",
   "localserv.no-ip.org",
   "locanto1.club",


### PR DESCRIPTION
The domain loanins.org is used as a DEA to create fake Wordpress accounts. Easy to check just googling.