### PR TITLE
Remove c2.hu

### DIFF
--- a/index.json
+++ b/index.json
@@ -2504,7 +2504,6 @@
   "c0sau0gpflgqv0uw2sg.ml",
   "c0sau0gpflgqv0uw2sg.tk",
   "c1oramn.com",
-  "c2.hu",
   "c20vussj1j4glaxcat.cf",
   "c20vussj1j4glaxcat.ga",
   "c20vussj1j4glaxcat.gq",


### PR DESCRIPTION
This is a standard free email provider, not a disposable one. As such it has been added to https://gitlab.com/synappio/free-email-domains