### PR TITLE
adding drivesotp7.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -3419,6 +3419,7 @@
   "drf.email",
   "drid1gs.com",
   "drivecompanies.com",
+  "drivesotp7.com",
   "drivetagdev.com",
   "drop.ekholm.org",
   "droplar.com",


### PR DESCRIPTION
found on emailondeck

![image](https://user-images.githubusercontent.com/3769077/43485627-b600e1f4-94df-11e8-9c98-da0eaf5f01f3.png)
