### PR TITLE
Add freeinbox.email

### DIFF
--- a/index.json
+++ b/index.json
@@ -4733,6 +4733,7 @@
   "freecat.net",
   "freedom4you.info",
   "freehosting.men",
+  "freeinbox.email",
   "freelance-france.eu",
   "freemail.ms",
   "freemail.tweakly.net",


### PR DESCRIPTION
From `freeinbox.email` domain (a French disposable domain)