### PR TITLE
Add disposable domains from temp-mail.org

### DIFF
--- a/index.json
+++ b/index.json
@@ -15117,4 +15117,17 @@
   "zymuying.com",
   "zzi.us",
   "zzz.com"
+  "mailboxy.fun",
+  "4senditnow.com",
+  "next2cloud.info",
+  "mail-apps.com",
+  "maillink.info",
+  "4mail.top",
+  "ace-mail.net",
+  "maxmail.info",
+  "myletter.online",
+  "shop4mail.net",
+  "next-mail.online",
+  "quick-mail.info",
+  "mymailbest.com",
 ]


### PR DESCRIPTION
Added the following domains from the service temp-mail.org

  "mailboxy.fun",
  "4senditnow.com",
  "next2cloud.info",
  "mail-apps.com",
  "maillink.info",
  "4mail.top",
  "ace-mail.net",
  "maxmail.info",
  "myletter.online",
  "shop4mail.net",
  "next-mail.online",
  "quick-mail.info",
  "mymailbest.com",