### PR TITLE
Added fuwa.li - another "aquapal" domain

### DIFF
--- a/index.json
+++ b/index.json
@@ -5255,6 +5255,7 @@
   "fuw65d.ml",
   "fuw65d.tk",
   "fuwa.be",
+  "fuwa.li",
   "fuwamofu.com",
   "fux0ringduh.com",
   "fvhnqf7zbixgtgdimpn.cf",


### PR DESCRIPTION
Another domain related to the visit http://fuwa.be/ http://ruru.be/ http://mofu.be/ set.