### PR TITLE
putsbox.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -13301,6 +13301,7 @@
   "putfs6fbkicck.gq",
   "putfs6fbkicck.ml",
   "putfs6fbkicck.tk",
+  "putsbox.com",
   "puttana.cf",
   "puttana.ga",
   "puttana.gq",


### PR DESCRIPTION
supposed to be used for testing emails, which allows you to create a dummy mailbox and then view the mailbox. so of course people are using it for disposables.