### PR TITLE
Remove aver.com from list

### DIFF
--- a/index.json
+++ b/index.json
@@ -5606,7 +5606,6 @@
   "avchina.us",
   "avenirshoes.ru",
   "avenueway.com",
-  "aver.com",
   "averdov.com",
   "averona72.ru",
   "aversale.com",


### PR DESCRIPTION
* The domain `aver.com` was originally added to the list in 2014 (https://github.com/ivolo/disposable-email-domains/pull/14)
* The domain ownership has since changed and the domain is used by a [reputable video conferencing company](https://aver.com)
* [WhoIs Information](https://who.is/whois/aver.com)