### PR TITLE
add mail2paste.com as disposable domain

### DIFF
--- a/index.json
+++ b/index.json
@@ -49944,6 +49944,7 @@
   "mail2nowhere.gq",
   "mail2nowhere.ml",
   "mail2nowhere.tk",
+  "mail2paste.com",
   "mail2rss.org",
   "mail3.top",
   "mail333.com",


### PR DESCRIPTION
According to https://fakecheck.email/mail2paste.com and, well, the _domain name itself_ this is a disposable email domain.