### PR TITLE
Remove 33mail.com because its aliases are not temporary

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # disposable-email-domains
 
-A list of [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address) like `mailinator.com`. You can use it to detect or block disposable accounts in your signup process. Exact domain matches are found in [index.json](https://github.com/ivolo/disposable-email-domains/blob/master/index.json) and wildcard domains (ex: `*.33mail.com`) are in [wildcard.json](https://github.com/ivolo/disposable-email-domains/blob/master/wildcard.json).
+A list of [disposable email domains](http://en.wikipedia.org/wiki/Disposable_email_address) like `mailinator.com`. You can use it to detect or block disposable accounts in your signup process. Exact domain matches are found in [index.json](https://github.com/ivolo/disposable-email-domains/blob/master/index.json) and wildcard domains (ex: `*.anonaddy.com`) are in [wildcard.json](https://github.com/ivolo/disposable-email-domains/blob/master/wildcard.json).
 
 # Examples
 

--- a/index.json
+++ b/index.json
@@ -2930,8 +2930,6 @@
   "33hg.bet",
   "33hhqp.com",
   "33jisu.com",
-  "33m.co",
-  "33mail.com",
   "33protector.ru",
   "33s.info",
   "33sil.site",

--- a/wildcard.json
+++ b/wildcard.json
@@ -2,8 +2,6 @@
   "0x01.gq",
   "0x01.tk",
   "10mail.org",
-  "33m.co",
-  "33mail.com",
   "3utilities.com",
   "acusupply.com",
   "adultvidlite.com",


### PR DESCRIPTION
Hi, I'm one of the creators of 33mail.

I'd like to request the removal of 33mail.com from this list because our aliases are not temporary, they remain active indefinitely unless a user chooses to block them. 

I have 33mail aliases that are 10 years old and still active, and across our system 90% of aliases are never blocked. 33mail deliverability and open rates are higher than normal emails because our users trust our system to block spam.

Much appreciated, and happy to answer any questions.