### PR TITLE
Removed localhomepro.com from list

### DIFF
--- a/index.json
+++ b/index.json
@@ -61165,7 +61165,6 @@
   "localddsnearme.com",
   "localempleo.com",
   "localheroes.ru",
-  "localhomepro.com",
   "localini.com",
   "localinternetbrandingsecrets.com",
   "localintucson.com",


### PR DESCRIPTION
The localhomepro.com domain is now valid, and points to Google mail domains, [as can be seen here](https://mxtoolbox.com/SuperTool.aspx?action=mx%3alocalhomepro.com&run=toolpage).