### PR TITLE
add xojxe.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -114284,6 +114284,7 @@
   "xohi.site",
   "xoifyjcyj.shop",
   "xoixa.com",
+  "xojxe.com",
   "xokdgw.site",
   "xolox.xyz",
   "xolymail.cf",


### PR DESCRIPTION
This is a domain used by 1secmail.com that we've seen popping up in user registrations recently.