### PR TITLE
Removes a personal, non-disposable domain

### DIFF
--- a/index.json
+++ b/index.json
@@ -89643,7 +89643,6 @@
   "rueportcent.ga",
   "rueportcent.gq",
   "ruetin.online",
-  "ruffrey.com",
   "rufiysmbz.shop",
   "rufoej.us",
   "rugbyfixtures.com",


### PR DESCRIPTION
I've been dealing with blocked and bouncing email for the past year. I'm not able to signup for many services. After much searching, I discovered my personal domain is incorrectly listed as disposable. It is unclear how it landed on this list. This is a mistake. My mail is hosted at namecheap. Look at the MX records yourself (`dig mx ruffrey.com`).
![image](https://user-images.githubusercontent.com/1668190/175988890-d3e70a63-287e-4fc1-82e5-cc3a5203b1f6.jpeg)

I only have one single email address under this domain. I have had this email address for 10 years.
