### PR TITLE
Remove edu.pl from the wildcard list

### DIFF
--- a/wildcard.json
+++ b/wildcard.json
@@ -50,7 +50,6 @@
   "dzalaev-advokat.ru",
   "e4ward.com",
   "edu.auction",
-  "edu.pl",
   "efo.kr",
   "eho.kr",
   "ely.kr",


### PR DESCRIPTION
Fix #935 
Apparently wildcard is too strict for this one. Compare e.g. https://check-mail.org/domain/edu.pl/ vs https://check-mail.org/domain/pw.edu.pl/