### PR TITLE
Add xgmail.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -116321,6 +116321,7 @@
   "xgk6dy3eodx9kwqvn.tk",
   "xgl4nb.com",
   "xglmedia.com",
+  "xgmail.com",
   "xgmailoo.com",
   "xgnowherei.com",
   "xgoiuu.xyz",


### PR DESCRIPTION
Thanks for `disposable-email-domains`! Super useful.

A quick PR to add `xgmail.com`, which appears to be another throwaway / temporary / disposable email domain from research.