### PR TITLE
Improve DX for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.62",
   "repository": "https://github.com/ivolo/disposable-email-domains.git",
   "license": "MIT",
-  "main": "./index.json",
+  "main": "index.js",
   "scripts": {
     "test": "mocha || true",
     "add": "node add.js",


### PR DESCRIPTION
A quick PR to improve the DX (Developer Experience) for ES Modules (using the `import` keyword).

Right now, if you use `disposable-email-domains` using `import` in Node.js, you receive an error:

```js
// index.js
import domains from 'disposable-email-domains';
```

Error message:

```bash
$ node index.js
node:internal/errors:465
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///home/runner/RepentantTransparentAudacity/node_modules/disposable-email-domains/index.json" needs an import assertion of type "json"
    at new NodeError (node:internal/errors:372:5)
    at validateAssertions (node:internal/modules/esm/assert:82:15)
    at defaultLoad (node:internal/modules/esm/load:24:3)
    at ESMLoader.load (node:internal/modules/esm/loader:407:26)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:326:22)
    at new ModuleJob (node:internal/modules/esm/module_job:66:26)
    at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:345:17)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:304:34)
    at async ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:82:21) {
  code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING'
}
```

You can resolve this error using the `{ type: 'json' }` import assertion as shown below, but this is still experimental:

```js
import domains from 'disposable-email-domains' assert { type: 'json' };
```

It shows a warning in Node.js 18.12.1 and is not supported at all in older versions:

```bash
$ node index.js
(node:376) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

This PR allows for usage of the simpler `import` syntax without the import assertion.