### PR TITLE
Remove AnonAddy domains

### DIFF
--- a/wildcard.json
+++ b/wildcard.json
@@ -15,8 +15,6 @@
   "acusupply.com",
   "adultvidlite.com",
   "aji.kr",
-  "anonaddy.com",
-  "anonaddy.me",
   "anonbox.net",
   "anyalias.com",
   "asanatest1.us",


### PR DESCRIPTION
For the same reason that SimpleLogin #846 , Firefox Relay #871 and DuckDuckGo's domains are not on the list. AnonAddy is not a disposable email provider.