### PR TITLE
Remove Lendscape Domain

### DIFF
--- a/index.json
+++ b/index.json
@@ -62126,7 +62126,6 @@
   "lendingshop.site",
   "lendlesssn.com",
   "lendoapp.co",
-  "lendscape.com",
   "lenestate.ru",
   "lenfly.com",
   "lengworcomp.gq",


### PR DESCRIPTION
Lendscape was disposable domain, but now is owned by a [financial technology company](https://www.lendscape.com/) and hosts real mailboxes.