### PR TITLE
Update emails.txt to remove ubicloud.com

### DIFF
--- a/index.json
+++ b/index.json
@@ -108044,7 +108044,6 @@
   "uberketing.com",
   "uberone.info",
   "ubersetzer.nyc",
-  "ubicloud.com",
   "ubiqi.net",
   "ubiquemarketing.com",
   "ubismail.net",


### PR DESCRIPTION
Ubicloud.com is our startup's domain and has its SPF, DKIM, and DMARC records properly configured.

Every time we need to sign up to a SaaS service such as Slack, Heroku, levels.fyi, etc., we need to contact their dev team. This pull request fixes the source blacklist instead.