### PR TITLE
Removal of fresent.com, as Fresent LLC is a legitimate USA company

### DIFF
--- a/index.json
+++ b/index.json
@@ -42323,7 +42323,6 @@
   "frepsalan.xyz",
   "freresphone.com",
   "fresco-pizzeria-ballybrittas.com",
-  "fresent.com",
   "fresh91.casino",
   "freshappcasgreen.ru",
   "freshestcoffeepossible.com",


### PR DESCRIPTION
Removal of fresent.com, as Fresent LLC is a legitimate USA company