### PR TITLE
Add temp-mail.io domain to disposable email blocklist

### DIFF
--- a/index.json
+++ b/index.json
@@ -121567,5 +121567,6 @@
   "zzz813.com",
   "zzz98.xyz",
   "zzzpush.icu",
-  "zzzz1717.com"
+  "zzzz1717.com",
+  "bwmyga.com"
 ]


### PR DESCRIPTION
- Updated the disposable email validation list to include temp-mail.io/en.
- This ensures users cannot register using temporary email addresses from temp-mail.io.
- Enhances security and reduces spam/fraudulent sign-ups on the platform.